### PR TITLE
Improve dev process, make compatible with React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "webpack-dev-server --content-base example/",
     "build": "webpack",
-    "compile": "babel ./src/hamburger-menu.jsx --out-file ./dist/index.js",
+    "compile": "mkdir -p dist && babel ./src/hamburger-menu.jsx --out-file ./dist/index.js",
     "prepublish": "npm run compile",
     "test": "tape -r babel-register ./src/**/*.spec.js | tap-spec"
   },
@@ -35,14 +35,15 @@
     "babel-preset-react": "6.3.13",
     "babel-preset-stage-0": "6.3.13",
     "expect": "1.13.4",
-    "react-addons-test-utils": "0.14.3",
-    "react-dom": "0.14.5",
+    "react-addons-test-utils": "0.14.3 || ^15.0.0",
+    "react": "0.14.5 || ^15.0.0",
+    "react-dom": "0.14.5 || ^15.0.0",
     "tap-spec": "4.1.1",
     "tape": "4.4.0",
     "webpack": "1.12.9",
     "webpack-dev-server": "1.14.0"
   },
   "peerDependencies": {
-    "react": "0.14.5"
+    "react": "0.14.5 || ^15.0.0"
   }
 }

--- a/src/hamburger-menu.jsx
+++ b/src/hamburger-menu.jsx
@@ -6,8 +6,8 @@ export default function HamburgerMenu(props) {
 	halfHeight        = `${parseInt(height.replace('px', '')) / 2}px`,
 	isOpen            = props.isOpen || false,
 	strokeWidth       = props.strokeWidth || 2,
-  halfStrokeWidth   = `-${strokeWidth / 2}`,
-  animationDuration = props.animationDuration || '0.4';
+    halfStrokeWidth   = `-${strokeWidth / 2}px`,
+    animationDuration = props.animationDuration || '0.4';
 
 	const getTransformValue = (isOpen, defaultPos, rotateVal) => (
 		`translate3d(0,${isOpen ? halfHeight : defaultPos},0) rotate(${isOpen ? `${rotateVal}deg` : '0'})`


### PR DESCRIPTION
The missing `px` was causing a warning in React 15.

When developing, I couldn't get it running, realized the `dist` directory needs to be created, so I added that too.
